### PR TITLE
fix: changed flow-bin npm package to a peer and dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "author": "kumar.mcmillan@gmail.com",
   "license": "MIT",
   "dependencies": {
-    "flow-bin": "^0.33.0",
     "object-assign": "4.1.0",
     "when": "3.7.7"
   },
@@ -28,6 +27,7 @@
   ],
   "devDependencies": {
     "chai": "3.5.0",
+    "flow-bin": "0.33.0",
     "grunt": "1.0.1",
     "grunt-mocha-test": "0.13.2",
     "load-grunt-configs": "1.0.0",
@@ -36,6 +36,7 @@
     "sinon": "1.17.6"
   },
   "peerDependencies": {
+    "flow-bin": ">= 0.30.0 < 0.40.0",
     "grunt": "~1.0.0"
   }
 }


### PR DESCRIPTION
This PR removes flow-bin from the direct dependencies of this package and turned it into both a peer and dev dependency instead.

By directly depending from a specific flow-bin version, this package ends to always use this flow-bin version, while, on the contrary, it would be probably better to use the version choosen by the package that depends on this one, e.g.:

web-ext directly depends on flow-bin 0.33.0 and when the grunt flowbin tasks are executed (the ones defined by this package) the flow version should be used to run the checks should be one installed by web-ext (instead of the one indirectly installed by the grunt-flowbin dependency).
